### PR TITLE
PFE-69: Fix module error when importing images

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -1,0 +1,2 @@
+declare module '*.png'
+declare module '*.svg'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src"
+    "src",
+    ".d.ts"
   ]
 }


### PR DESCRIPTION
TS wouldn't detect images. this fixes it. we can add more image types later but for now we will only be using png and svg