### PR TITLE
PFE-68: Update header to have logo

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -94,7 +94,7 @@ const Header: React.FC<Props> = ({ isAuthenticated }) => {
         <AppBar position="static" color="inherit">
             <Toolbar>
                 <Link to="/" style={{ display: 'flex', alignContent: 'center' }}>
-                    <img src={Logo} style={{ flexGrow: 1 }} />
+                    <img src={Logo} alt="Finberry Logo" style={{ flexGrow: 1 }} />
                 </Link>
                 {isAuthenticated ? authLinks : guestLinks}
             </Toolbar>


### PR DESCRIPTION
replaces the "logo placeholder" in the header with an actual image of our logo
![image](https://user-images.githubusercontent.com/30279572/216808021-04db3eef-432c-491b-a9ca-8e71b366f402.png)
